### PR TITLE
Nginx catches all non-root paths

### DIFF
--- a/docker/nginx/templates/nginx.conf
+++ b/docker/nginx/templates/nginx.conf
@@ -1,10 +1,6 @@
 server {
     listen ${FRONTEND_PORT};
 
-    location / {
-        root /usr/share/nginx/html;
-    }
-
     location /api {
         proxy_pass ${PROXY_API}/api/v1;
     }
@@ -12,4 +8,7 @@ server {
     location /api/healthz {
         proxy_pass ${PROXY_API}/healthz;
     }
+
+    root /usr/share/nginx/html;
+    try_files $uri /$uri /index.html;
 }


### PR DESCRIPTION
We use react-router as our way of navigating between pages but since Nginx is the web server entrypoint, it will attempt to load non-root paths according to the nginx config.

Ideally, we want all routing behaviour to be handled by react-router but since nginx is our entrypoint, we encounter unwanted behaviour.

If we navigate to an unknown page `/test` we would expect to see our custom 404 page but as-is, we would see Nginx's default 500 error page (or something similar)

This PR adjusts the config so that all requests will lead to our react app and be handled by react-router.
